### PR TITLE
Check if file exists before trying to remove.

### DIFF
--- a/data_processing/convert_base.py
+++ b/data_processing/convert_base.py
@@ -195,7 +195,8 @@ class BaseConvert(object):
         Deletes all temporary files used in the processing chain.
         """
         for filename in self._temp_files:
-            os.remove(filename)
+            if os.path.exists(filename):
+                os.remove(filename)
 
     @staticmethod
     def process_record(record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:


### PR DESCRIPTION
Fixes a problem that occurs when the conversion fails before creating a temporary file. Example execution and error message:

    (py39) [asreimer@fedora-vm borealis_postprocessors]$ python conversion.py /home/asreimer/files/impt_test_nov2021/20211115.1700.27.rkn.0.bfiq.hdf5.site.bz2 /home/asreimer/files/impt_test_nov2021/20211115.1700.27.rkn.0.rawacf bfiq rawacf site dmap
    Could not process file /home/asreimer/files/impt_test_nov2021/20211115.1700.27.rkn.0.bfiq.hdf5.site.bz2 -> /home/asreimer/files/impt_test_nov2021/20211115.1700.27.rkn.0.rawacf. Removing all newly generated files.
    Traceback (most recent call last):
      File "/home/asreimer/src/borealis_postprocessors/conversion.py", line 183, in <module>
        main()
      File "/home/asreimer/src/borealis_postprocessors/conversion.py", line 178, in main
        ConvertFile(args.infile, args.outfile, args.infile_type, args.outfile_type, args.infile_structure,
      File "/home/asreimer/src/borealis_postprocessors/conversion.py", line 113, in __init__
        self._converter = self.get_converter()
      File "/home/asreimer/src/borealis_postprocessors/conversion.py", line 156, in get_converter
        return ProcessBfiq2Rawacf(self.infile, self.outfile, self.infile_structure, self.outfile_structure,
      File "/home/asreimer/src/borealis_postprocessors/data_processing/bfiq_to_rawacf.py", line 76, in __init__
        self.process_file()
      File "/home/asreimer/src/borealis_postprocessors/data_processing/convert_base.py", line 191, in process_file
        self._remove_temp_files()
      File "/home/asreimer/src/borealis_postprocessors/data_processing/convert_base.py", line 198, in _remove_temp_files
        os.remove(filename)
    FileNotFoundError: [Errno 2] No such file or directory: '/home/asreimer/files/impt_test_nov2021/20211115.1700.27.rkn.0.rawacf.site.tmp'