### PR TITLE
Memory management

### DIFF
--- a/data_processing/convert_base.py
+++ b/data_processing/convert_base.py
@@ -6,7 +6,6 @@ to bfiq files.
 """
 import os
 import subprocess as sp
-import sys
 from collections import OrderedDict
 from typing import Union
 import deepdish as dd


### PR DESCRIPTION
* Load only one record at a time into memory when converting files.
* Initial tests show that this is about twice as fast as loading the entire file into memory.