### PR TITLE
Deepdish deprecation

### DIFF
--- a/postprocessors/core/convert_base.py
+++ b/postprocessors/core/convert_base.py
@@ -5,16 +5,14 @@ This file contains functions for converting antennas_iq files
 to bfiq files.
 """
 import os
-import subprocess as sp
 import traceback
 from collections import OrderedDict
 from typing import Union
-import deepdish as dd
 import h5py
 from functools import partial
 from multiprocessing import get_context
 
-from postprocessors.core.restructure import restructure, convert_to_numpy, FILE_STRUCTURE_MAPPING
+import postprocessors.core.restructure as rs
 from postprocessors import conversion_exceptions
 
 try:
@@ -30,8 +28,8 @@ import logging
 postprocessing_logger = logging.getLogger('borealis_postprocessing')
 
 
-def processing_machine(idx: int, filename: str, record_keys: list, records_per_process: int, averaging_method: str,
-                       processing_fn, **kwargs):
+def processing_machine(idx: int, filename: str, record_keys: list, records_per_process: int,
+                       averaging_method: str, processing_fn, **kwargs):
     """
     Helper function for processing a single record. It is defined here to facilitate multiprocessing.
 
@@ -40,7 +38,7 @@ def processing_machine(idx: int, filename: str, record_keys: list, records_per_p
     idx: int
         Index into record_keys which tells processing_machine() which record to process
     filename: str
-        Name of the HDF5 file with records to process.
+        HDF5 file with records to process.
     record_keys: list
         List of all top-level keys of the HDF5 file.
     records_per_process: int
@@ -56,21 +54,22 @@ def processing_machine(idx: int, filename: str, record_keys: list, records_per_p
     -------
     formatted_record, idx: properly-formatted processed record and the index which was processed.
     """
-    record_dict = dd.io.load(filename, f'/{record_keys[idx]}')
-    record_list = []  # List of all 'extra' records to process
+    with h5py.File(filename, 'r') as hdf5_file:
+        record_dict = rs.read_group(hdf5_file[record_keys[idx]])
+        record_list = []  # List of all 'extra' records to process
 
-    # If processing multiple records at a time, get all the records ready
-    if records_per_process > 1:
-        for num in range(idx + 1, min(idx + records_per_process, len(record_keys))):
-            record_list.append(dd.io.load(filename, f'/{record_keys[num]}'))
+        # If processing multiple records at a time, get all the records ready
+        if records_per_process > 1:
+            for num in range(idx + 1, min(idx + records_per_process, len(record_keys))):
+                record_list.append(rs.read_group(hdf5_file[record_keys[num]]))
 
     processed_record = processing_fn(record_dict, averaging_method, extra_records=record_list, **kwargs)
 
     if processed_record is None:
         return None, idx
     else:
-        # Convert to numpy arrays for saving to file with deepdish
-        formatted_record = convert_to_numpy(processed_record)
+        # Convert to numpy arrays for saving to file
+        formatted_record = rs.convert_to_numpy(processed_record)
         return formatted_record, idx
 
 
@@ -153,17 +152,17 @@ class BaseConvert(object):
 
     def check_args(self):
 
-        if self.infile_structure not in FILE_STRUCTURE_MAPPING[self.infile_type]:
+        if self.infile_structure not in rs.FILE_STRUCTURE_MAPPING[self.infile_type]:
             raise conversion_exceptions.ImproperFileStructureError(
                 f'Input file structure "{self.infile_structure}" is not compatible with input file type '
                 f'"{self.infile_type}": Valid structures for {self.infile_type} are '
-                f'{FILE_STRUCTURE_MAPPING[self.infile_type]}'
+                f'{rs.FILE_STRUCTURE_MAPPING[self.infile_type]}'
             )
-        if self.outfile_structure not in FILE_STRUCTURE_MAPPING[self.outfile_type]:
+        if self.outfile_structure not in rs.FILE_STRUCTURE_MAPPING[self.outfile_type]:
             raise conversion_exceptions.ImproperFileStructureError(
                 f'Output file structure "{self.outfile_structure}" is not compatible with output file type '
                 f'"{self.outfile_type}": Valid structures for {self.outfile_type} are '
-                f'{FILE_STRUCTURE_MAPPING[self.outfile_type]}'
+                f'{rs.FILE_STRUCTURE_MAPPING[self.outfile_type]}'
             )
         if self.infile_structure not in ['array', 'site']:
             raise conversion_exceptions.ConversionUpstreamError(
@@ -199,7 +198,7 @@ class BaseConvert(object):
                 self._temp_files.append(file_to_process)
                 # Restructure file to site format for processing
                 postprocessing_logger.info(f'Restructuring file {self.infile} --> {file_to_process}')
-                restructure(self.infile, file_to_process, self.infile_type, self.infile_structure, 'site')
+                rs.restructure(self.infile, file_to_process, self.infile_type, self.infile_structure, 'site')
             else:
                 file_to_process = self.infile
 
@@ -218,52 +217,46 @@ class BaseConvert(object):
                 with h5py.File(processed_file, 'r') as f:
                     finished_records = set(f.keys())
 
-            # Load file
-            with h5py.File(file_to_process, 'r') as f:
-                all_records = sorted(list(f.keys()))
-                records_per_process = kwargs.get('avg_num', 1)      # Records are getting averaged together.
+            # Load record names from file
+            with h5py.File(file_to_process, 'r') as infile:
+                all_records = sorted(list(infile.keys()))
 
-                if not kwargs.get('force', False):  # file may be partially processed, only process remaining records
-                    final_records_remaining = sorted(list(
-                        set(all_records[::records_per_process]).difference(finished_records)))
+            records_per_process = kwargs.get('avg_num', 1)      # Records getting averaged together.
+            if not kwargs.get('force', False):      # file may be partially processed, only process remaining records
+                final_records_remaining = sorted(list(
+                    set(all_records[::records_per_process]).difference(finished_records)))
+            else:
+                final_records_remaining = all_records[::records_per_process]
 
-                first_idx = all_records.index(final_records_remaining[0])   # first record to process
-                num_to_process = round(len(all_records) / records_per_process)
-                num_completed = first_idx
-                indices = range(first_idx, len(all_records), records_per_process)
+            first_idx = all_records.index(final_records_remaining[0])   # first record to process
+            num_to_process = round(len(all_records) / records_per_process)
+            num_completed = first_idx
+            indices = range(first_idx, len(all_records), records_per_process)
 
-                with get_context("spawn").Pool(kwargs.get('num_processes', 5)) as p:
+            with get_context("spawn").Pool(kwargs.get('num_processes', 5)) as p:
+                function_to_call = partial(processing_machine,
+                                           filename=file_to_process, record_keys=all_records,
+                                           records_per_process=records_per_process,
+                                           averaging_method=self.averaging_method,
+                                           processing_fn=self.process_record, **kwargs)
+                print()     # Put the progress bar on a newline
 
-                    function_to_call = partial(processing_machine,
-                                               filename=file_to_process, record_keys=all_records,
-                                               records_per_process=records_per_process,
-                                               averaging_method=self.averaging_method,
-                                               processing_fn=self.process_record, **kwargs)
-                    print() # Put the progress bar on a newline
+                with h5py.File(processed_file, 'a') as outfile:
                     for completed_record, i in p.imap(function_to_call, indices):
                         num_completed += 1
                         if completed_record is not None:
-                            # Save record to temporary file
-                            tempfile = f'/tmp/{all_records[i]}.tmp'
-                            dd.io.save(tempfile, completed_record, compression=None)
-
-                            # Copy record to output file
-                            cmd = f'h5copy -i {tempfile} -o {processed_file} -s / -d {all_records[i]}'
-                            sp.call(cmd.split())
-
-                            # Remove temporary file
-                            os.remove(tempfile)
+                            rs.write_records(outfile, {all_records[i]: completed_record})
                         completion_percentage = num_completed / num_to_process
                         bar_width = 60  # arbitrary width
                         filled = int(bar_width * completion_percentage)
                         unfilled = bar_width - filled
                         print(f'\r[{"="*filled}{" "*unfilled}] {completion_percentage*100:.2f}%', flush=True, end='')
-                    print()     # Keep the progress bar on its own line
+                print()     # Keep the progress bar on its own line
 
             # Restructure to final structure format, if necessary
             if self.outfile_structure != 'site':
                 postprocessing_logger.info(f'Restructuring file {processed_file} --> {self.outfile}')
-                restructure(processed_file, self.outfile, self.outfile_type, 'site', self.outfile_structure)
+                rs.restructure(processed_file, self.outfile, self.outfile_type, 'site', self.outfile_structure)
         except (Exception,) as e:
             postprocessing_logger.error(f'Could not process file {self.infile} -> {self.outfile}. Removing all newly'
                                         f' generated files.')

--- a/postprocessors/core/restructure.py
+++ b/postprocessors/core/restructure.py
@@ -83,7 +83,10 @@ def write_records(hdf5_file: h5py.File, records: dict):
                 array_field = True
             elif isinstance(v, np.ndarray):
                 if isinstance(v[0], str):
-                    data = np.bytes_(v)
+                    dset = group.create_dataset(k, data=v.view(dtype=np.uint8))
+                    dset.attrs['strtype'] = b'unicode'
+                    dset.attrs['itemsize'] = v.dtype.itemsize // 4  # every character is 4 bytes
+                    continue
                 else:
                     data = v
                 array_field = True

--- a/postprocessors/core/restructure.py
+++ b/postprocessors/core/restructure.py
@@ -6,6 +6,95 @@ This module provides some functions which are used in the processing of Borealis
 """
 import pydarnio
 import numpy as np
+import h5py
+
+
+def read_group(group: h5py.Group):
+    """
+    Reads a group from an HDF5 file into a dictionary.
+
+    Parameters
+    ----------
+    group: h5py.Group
+        Opened h5py group
+
+    Returns
+    -------
+    dict
+        Dictionary of {group_name: {}} where the inner dictionary is the datasets/attributes
+        of the hdf5 group.
+    """
+    group_dict = {}
+    # Get the datasets (vector fields)
+    datasets = list(group.keys())
+    for dset_name in datasets:
+        dset = group[dset_name]
+        if 'strtype' in dset.attrs:  # string type, requires some handling
+            itemsize = dset.attrs['itemsize']
+            data = dset[:].view(dtype=(np.unicode_, itemsize))
+        else:
+            data = dset[:]  # non-string, can simply load
+        group_dict[dset_name] = data
+
+    # Get the attributes (scalar fields)
+    attribute_dict = {}
+    for k, v in group.attrs.items():
+        if k in ['CLASS', 'TITLE', 'VERSION', 'DEEPDISH_IO_VERSION', 'PYTABLES_FORMAT_VERSION']:
+            continue
+        elif isinstance(v, np.bytes_):
+            attribute_dict[k] = v.tobytes().decode('utf-8')
+        elif isinstance(v, h5py.Empty):
+            dtype = v.dtype.type
+            data = dtype()
+            if isinstance(data, bytes):
+                data = data.decode('utf-8')
+            attribute_dict[k] = data
+        else:
+            attribute_dict[k] = v
+    group_dict.update(attribute_dict)
+
+    return group_dict
+
+
+def write_records(hdf5_file: h5py.File, records: dict):
+    """
+    Write the record to file.
+
+    Parameters
+    ----------
+    hdf5_file: h5py.File
+       HDF5 file to write records to.
+    records: dict
+        Dictionary containing fields to write to file.
+    """
+    for group_name, group_dict in records.items():
+        group = hdf5_file.create_group(str(group_name))
+        for k, v in group_dict.items():
+            array_field = False
+            if isinstance(v, str):
+                data = np.bytes_(v)
+            elif isinstance(v, bool):
+                data = np.bool_(v)
+            elif isinstance(v, list):
+                if isinstance(v[0], str):
+                    data = np.bytes_(v)
+                else:
+                    data = np.array(v)
+                array_field = True
+            elif isinstance(v, np.ndarray):
+                if isinstance(v[0], str):
+                    data = np.bytes_(v)
+                else:
+                    data = v
+                array_field = True
+            else:
+                data = v
+
+            # Store in the file appropriately
+            if array_field:
+                group.create_dataset(k, data=data)
+            else:
+                group.attrs[k] = data
 
 
 def restructure(infile_name, outfile_name, infile_type, infile_structure, outfile_structure):

--- a/postprocessors/sandbox/bistatic_processing.py
+++ b/postprocessors/sandbox/bistatic_processing.py
@@ -5,8 +5,8 @@ This file contains functions for processing bistatic_test antennas_iq files to r
 """
 from collections import OrderedDict
 from typing import Union
+import h5py
 import numpy as np
-import deepdish as dd
 
 from postprocessors import BaseConvert, ProcessAntennasIQ2Rawacf
 
@@ -59,10 +59,10 @@ class BistaticProcessing(BaseConvert):
         """
         super().__init__(infile, outfile, 'antennas_iq', 'rawacf', infile_structure, outfile_structure)
 
-        timestamps_opened = dd.io.load(timestamps_file)   # Load the whole file in
-        keys = sorted(list(timestamps_opened.keys()))
+        with h5py.File(timestamps_file, 'r') as tstamp_file:
+            keys = sorted(list(tstamp_file.keys()))
 
-        timestamps = np.concatenate([timestamps_opened[k]['data']['sqn_timestamps'] for k in keys])
+            timestamps = np.concatenate([tstamp_file[k]['data']['sqn_timestamps'][:] for k in keys])
         timestamps = np.around(timestamps, decimals=6)      # round to nearest microsecond
 
         self.process_file(timestamps=timestamps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     'Operating System :: Linux',
 ]
 keywords = ['SuperDARN', 'Borealis']
-dependencies = ['numpy', 'pyDARNio', 'h5py', 'deepdish', 'scipy', ]
+dependencies = ['numpy', 'pyDARNio', 'h5py', 'scipy', ]
 requires-python = '>=3.6'
 
 [project.optional-dependencies]

--- a/test/test_antiq2bfiq.py
+++ b/test/test_antiq2bfiq.py
@@ -14,24 +14,24 @@ if __name__ == '__main__':
     compare_site_file = 'bfiq.hdf5.site'
     compare_array_file = 'bfiq.hdf5'
 
-    # # Convert from site file to both site and array files
-    # pp.ConvertFile(site_infile, site_outfile, 'antennas_iq', 'bfiq', 'site', 'site')
-    # compare_files(compare_site_file, site_outfile)
+    # Convert from site file to both site and array files
+    pp.ConvertFile(site_infile, site_outfile, 'antennas_iq', 'bfiq', 'site', 'site')
+    compare_files(compare_site_file, site_outfile)
 
     pp.ConvertFile(site_infile, array_outfile, 'antennas_iq', 'bfiq', 'site', 'array')
     compare_files(compare_array_file, array_outfile)
 
     # Remove the generated files
-    # os.remove(site_outfile)
+    os.remove(site_outfile)
     os.remove(array_outfile)
 
-    # # Convert from array file to both site and array files
-    # pp.ConvertFile(array_infile, site_outfile, 'antennas_iq', 'bfiq', 'array', 'site')
-    # compare_files(compare_site_file, site_outfile)
-    #
-    # pp.ConvertFile(array_infile, array_outfile, 'antennas_iq', 'bfiq', 'array', 'array')
-    # compare_files(compare_array_file, array_outfile)
-    #
-    # # Remove the generate files
-    # os.remove(site_outfile)
-    # os.remove(array_outfile)
+    # Convert from array file to both site and array files
+    pp.ConvertFile(array_infile, site_outfile, 'antennas_iq', 'bfiq', 'array', 'site')
+    compare_files(compare_site_file, site_outfile)
+
+    pp.ConvertFile(array_infile, array_outfile, 'antennas_iq', 'bfiq', 'array', 'array')
+    compare_files(compare_array_file, array_outfile)
+
+    # Remove the generate files
+    os.remove(site_outfile)
+    os.remove(array_outfile)

--- a/test/test_antiq2bfiq.py
+++ b/test/test_antiq2bfiq.py
@@ -14,24 +14,24 @@ if __name__ == '__main__':
     compare_site_file = 'bfiq.hdf5.site'
     compare_array_file = 'bfiq.hdf5'
 
-    # Convert from site file to both site and array files
-    pp.ConvertFile(site_infile, site_outfile, 'antennas_iq', 'bfiq', 'site', 'site')
-    compare_files(compare_site_file, site_outfile)
+    # # Convert from site file to both site and array files
+    # pp.ConvertFile(site_infile, site_outfile, 'antennas_iq', 'bfiq', 'site', 'site')
+    # compare_files(compare_site_file, site_outfile)
 
     pp.ConvertFile(site_infile, array_outfile, 'antennas_iq', 'bfiq', 'site', 'array')
     compare_files(compare_array_file, array_outfile)
 
     # Remove the generated files
-    os.remove(site_outfile)
+    # os.remove(site_outfile)
     os.remove(array_outfile)
 
-    # Convert from array file to both site and array files
-    pp.ConvertFile(array_infile, site_outfile, 'antennas_iq', 'bfiq', 'array', 'site')
-    compare_files(compare_site_file, site_outfile)
-
-    pp.ConvertFile(array_infile, array_outfile, 'antennas_iq', 'bfiq', 'array', 'array')
-    compare_files(compare_array_file, array_outfile)
-
-    # Remove the generate files
-    os.remove(site_outfile)
-    os.remove(array_outfile)
+    # # Convert from array file to both site and array files
+    # pp.ConvertFile(array_infile, site_outfile, 'antennas_iq', 'bfiq', 'array', 'site')
+    # compare_files(compare_site_file, site_outfile)
+    #
+    # pp.ConvertFile(array_infile, array_outfile, 'antennas_iq', 'bfiq', 'array', 'array')
+    # compare_files(compare_array_file, array_outfile)
+    #
+    # # Remove the generate files
+    # os.remove(site_outfile)
+    # os.remove(array_outfile)

--- a/test/utils/compare_files.py
+++ b/test/utils/compare_files.py
@@ -4,12 +4,13 @@
 This file contains functions for comparing the contents of two HDF5 files.
 """
 import deepdish as dd
+import h5py
 import numpy as np
 
 
 def compare_files(file1, file2):
-    group1 = dd.io.load(file1)
-    group2 = dd.io.load(file2)
+    group1 = h5py.File(file1, 'r')
+    group2 = h5py.File(file2, 'r')
 
     def compare_dictionaries(dict1, dict2, prefix):
         compare_string = ""
@@ -18,6 +19,12 @@ def compare_files(file1, file2):
         uniq1 = keys1.difference(keys2)
         uniq2 = keys2.difference(keys1)
         shared = keys1.intersection(keys2)
+
+        attrs1 = set(dict1.attrs.keys())
+        attrs2 = set(dict2.attrs.keys())
+        uniq_attrs1 = attrs1.difference(attrs2)
+        uniq_attrs2 = attrs2.difference(attrs1)
+        shared_attrs = attrs1.intersection(attrs2)
 
         try:
             assert len(uniq1) == len(uniq2) == 0
@@ -33,7 +40,7 @@ def compare_files(file1, file2):
             if type(entry1) != type(entry2):
                 compare_string += prefix + f'Mismatched types for key {key}'
             # If they are dictionaries, recurse
-            elif type(entry1) == dict:
+            elif type(entry1) == h5py.Group:
                 compare_dictionaries(entry1, entry2, prefix + '\t')
             # Otherwise, they must be lists or values, and so can be compared directly
             else:
@@ -48,7 +55,7 @@ def compare_files(file1, file2):
                     equal = False
 
                 if not equal:
-                    compare_string += prefix + f"/{key}\n"
+                    compare_string += prefix + f"/{key}:\n\t{entry1}\n\t{entry2}\n"
 
         return compare_string
 

--- a/test/utils/compare_files.py
+++ b/test/utils/compare_files.py
@@ -3,7 +3,6 @@
 """
 This file contains functions for comparing the contents of two HDF5 files.
 """
-import deepdish as dd
 import h5py
 import numpy as np
 
@@ -44,18 +43,19 @@ def compare_files(file1, file2):
                 compare_dictionaries(entry1, entry2, prefix + '\t')
             # Otherwise, they must be lists or values, and so can be compared directly
             else:
-                equal = True
-
                 # Compare floating-point values differently
                 if 'float' in str(entry1.dtype) or 'complex' in str(entry1.dtype):
                     if not np.allclose(entry1, entry2, equal_nan=True):
-                        equal = False
+                        compare_string += prefix + f"/{key}:\n" \
+                                                   f"\t{entry1}\n" \
+                                                   f"\t{entry2}\n" \
+                                                   f"\tDifference: " \
+                                                   f"{np.nanmax(np.abs((entry1[:] - entry2[:])/entry1[:]))}\n"
                 # Comparing non-floating-point values
                 elif not np.array_equal(entry1, entry2):
-                    equal = False
-
-                if not equal:
-                    compare_string += prefix + f"/{key}:\n\t{entry1}\n\t{entry2}\n"
+                    compare_string += prefix + f"/{key}:\n" \
+                                               f"\t{entry1}\n" \
+                                               f"\t{entry2}\n"
 
         return compare_string
 


### PR DESCRIPTION
Removes any dependency on deepdish since it is no longer maintained. h5py is used for all HDF5 I/O from now on.