### PR TITLE
Class refactor and Additional Beamforming Methods

### DIFF
--- a/postprocessors/__init__.py
+++ b/postprocessors/__init__.py
@@ -10,9 +10,9 @@ from .exceptions import processing_exceptions
 
 # The main processing classes
 from .core.convert_base import BaseConvert
-from .core.antennas_iq_to_bfiq import ProcessAntennasIQ2Bfiq
-from .core.bfiq_to_rawacf import ProcessBfiq2Rawacf
-from .core.antennas_iq_to_rawacf import ProcessAntennasIQ2Rawacf
+from .core.antennas_iq_to_bfiq import AntennasIQ2Bfiq
+from .core.bfiq_to_rawacf import Bfiq2Rawacf
+from .core.antennas_iq_to_rawacf import AntennasIQ2Rawacf
 from .core.conversion import ConvertFile
 
 # Helpful for scripts

--- a/postprocessors/core/antennas_iq_to_bfiq.py
+++ b/postprocessors/core/antennas_iq_to_bfiq.py
@@ -71,8 +71,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         self.process_file(**kwargs)
 
-    @staticmethod
-    def process_record(record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+    @classmethod
+    def process_record(cls, record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
         """
         Takes a record from an antennas_iq file and converts it into a bfiq record.
 
@@ -88,20 +88,20 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
         record: OrderedDict
             hdf5 record, with new fields required by bfiq data format
         """
-        record['first_range'] = ProcessAntennasIQ2Bfiq.calculate_first_range(record)
-        record['first_range_rtt'] = ProcessAntennasIQ2Bfiq.calculate_first_range_rtt(record)
-        record['lags'] = ProcessAntennasIQ2Bfiq.create_lag_table(record)
-        record['range_sep'] = ProcessAntennasIQ2Bfiq.calculate_range_separation(record)
-        record['num_ranges'] = ProcessAntennasIQ2Bfiq.get_number_of_ranges(record)
-        record['data'] = ProcessAntennasIQ2Bfiq.beamform_data(record)
-        record['data_descriptors'] = ProcessAntennasIQ2Bfiq.get_data_descriptors()
-        record['data_dimensions'] = ProcessAntennasIQ2Bfiq.get_data_dimensions(record)
-        record['antenna_arrays_order'] = ProcessAntennasIQ2Bfiq.change_antenna_arrays_order()
+        record['first_range'] = cls.calculate_first_range(record)
+        record['first_range_rtt'] = cls.calculate_first_range_rtt(record)
+        record['lags'] = cls.create_lag_table(record)
+        record['range_sep'] = cls.calculate_range_separation(record)
+        record['num_ranges'] = cls.get_number_of_ranges(record)
+        record['data'] = cls.beamform_data(record)
+        record['data_descriptors'] = cls.get_data_descriptors()
+        record['data_dimensions'] = cls.get_data_dimensions(record)
+        record['antenna_arrays_order'] = cls.change_antenna_arrays_order()
 
         return record
 
-    @staticmethod
-    def beamform_data(record: OrderedDict) -> np.array:
+    @classmethod
+    def beamform_data(cls, record: OrderedDict) -> np.array:
         """
         Beamforms the data for each array, and stores it back into the record
 
@@ -144,28 +144,21 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
             # data input shape  = [num_antennas, num_samps]
             # data return shape = [num_beams, num_samps]
             main_beamformed_data = \
-                xp.append(main_beamformed_data,
-                          ProcessAntennasIQ2Bfiq.beamform(antennas_data[:len(main_antenna_indices), sequence, :],
-                                                          beam_azms,
-                                                          freq,
-                                                          main_antenna_count,
-                                                          main_antenna_spacing,
-                                                          main_antenna_indices))
+                xp.append(main_beamformed_data, cls.beamform(antennas_data[:len(main_antenna_indices), sequence, :],
+                                                             beam_azms, freq, main_antenna_count, main_antenna_spacing,
+                                                             main_antenna_indices))
+
             intf_beamformed_data = \
-                xp.append(intf_beamformed_data,
-                          ProcessAntennasIQ2Bfiq.beamform(antennas_data[len(main_antenna_indices):, sequence, :],
-                                                          beam_azms,
-                                                          freq,
-                                                          intf_antenna_count,
-                                                          intf_antenna_spacing,
-                                                          intf_antenna_indices))
+                xp.append(intf_beamformed_data, cls.beamform(antennas_data[len(main_antenna_indices):, sequence, :],
+                                                             beam_azms, freq, intf_antenna_count, intf_antenna_spacing,
+                                                             intf_antenna_indices))
 
         all_data = xp.append(main_beamformed_data, intf_beamformed_data).flatten()
 
         return all_data
 
-    @staticmethod
-    def beamform(antennas_data: np.array, beamdirs: np.array, rxfreq: float, ants_in_array: int, antenna_spacing: float,
+    @classmethod
+    def beamform(cls, antennas_data: np.array, beamdirs: np.array, rxfreq: float, ants_in_array: int, antenna_spacing: float,
                  antenna_indices: np.array) -> np.array:
         """
         Beamforms the data from each antenna and sums to create one dataset for each beam direction.
@@ -202,16 +195,12 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
             # Get phase shift for each antenna
             for antenna in antenna_indices:
-                phase_shift = ProcessAntennasIQ2Bfiq.get_phshift(beam_direction,
-                                                                 rxfreq,
-                                                                 antenna,
-                                                                 ants_in_array,
-                                                                 antenna_spacing)
+                phase_shift = cls.get_phshift(beam_direction, rxfreq, antenna, ants_in_array, antenna_spacing)
                 # Bring into range (-2*pi, 2*pi)
                 antenna_phase_shifts.append(phase_shift)
 
             # Apply phase shift to data from respective antenna
-            phased_antenna_data = [ProcessAntennasIQ2Bfiq.shift_samples(antennas_data[i], antenna_phase_shifts[i], 1.0)
+            phased_antenna_data = [cls.shift_samples(antennas_data[i], antenna_phase_shifts[i], 1.0)
                                    for i in range(num_antennas)]
             phased_antenna_data = xp.array(phased_antenna_data)
 
@@ -222,8 +211,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return beamformed_data
 
-    @staticmethod
-    def get_phshift(beamdir: float, freq: float, antenna: int, num_antennas: int, antenna_spacing: float,
+    @classmethod
+    def get_phshift(cls, beamdir: float, freq: float, antenna: int, num_antennas: int, antenna_spacing: float,
                     centre_offset: int = 0.0) -> float:
         """
         Find the phase shift for a given antenna and beam direction.
@@ -269,8 +258,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return phshift
 
-    @staticmethod
-    def shift_samples(basic_samples: np.array, phshift: float, amplitude: float = 1.) -> np.array:
+    @classmethod
+    def shift_samples(cls, basic_samples: np.array, phshift: float, amplitude: float = 1.) -> np.array:
         """
         Shift samples for a pulse by a given phase shift.
         Take the samples and shift by given phase shift in rads and adjust amplitude as
@@ -294,8 +283,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return samples
 
-    @staticmethod
-    def calculate_first_range(record: OrderedDict) -> float:
+    @classmethod
+    def calculate_first_range(cls, record: OrderedDict) -> float:
         """
         Calculates the distance from the main array to the first range (in km).
 
@@ -315,8 +304,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return xp.float32(first_range)
 
-    @staticmethod
-    def calculate_first_range_rtt(record: OrderedDict) -> float:
+    @classmethod
+    def calculate_first_range_rtt(cls, record: OrderedDict) -> float:
         """
         Calculates the round-trip time (in microseconds) to the first range in a record.
 
@@ -335,8 +324,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return xp.float32(first_range_rtt)
 
-    @staticmethod
-    def create_lag_table(record: OrderedDict) -> np.array:
+    @classmethod
+    def create_lag_table(cls, record: OrderedDict) -> np.array:
         """
         Creates the lag table for the record.
 
@@ -362,8 +351,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return lags
 
-    @staticmethod
-    def calculate_range_separation(record: OrderedDict) -> float:
+    @classmethod
+    def calculate_range_separation(cls, record: OrderedDict) -> float:
         """
         Calculates the separation between ranges in km.
 
@@ -382,8 +371,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return xp.float32(range_sep)
 
-    @staticmethod
-    def get_number_of_ranges(record: OrderedDict) -> int:
+    @classmethod
+    def get_number_of_ranges(cls, record: OrderedDict) -> int:
         """
         Gets the number of ranges for the record.
 
@@ -398,7 +387,7 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
             The number of ranges of the data
         """
         # Infer the number of ranges from the record metadata
-        first_range_offset = ProcessAntennasIQ2Bfiq.calculate_first_range_rtt(record) * 1e-6 * record['rx_sample_rate']
+        first_range_offset = cls.calculate_first_range_rtt(record) * 1e-6 * record['rx_sample_rate']
         num_ranges = record['num_samps'] - xp.int32(first_range_offset) - record['blanked_samples'][-1]
 
         # 3 extra samples taken for each record (not sure why)
@@ -406,8 +395,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return xp.uint32(num_ranges)
 
-    @staticmethod
-    def get_data_descriptors() -> list:
+    @classmethod
+    def get_data_descriptors(cls) -> list:
         """
         Returns the proper data descriptors for a bfiq file
 
@@ -420,8 +409,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return new_descriptors
 
-    @staticmethod
-    def get_data_dimensions(record: OrderedDict):
+    @classmethod
+    def get_data_dimensions(cls, record: OrderedDict):
         """
         Returns a list of the new data dimensions for a bfiq record.
 
@@ -444,8 +433,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
 
         return new_dimensions
 
-    @staticmethod
-    def change_antenna_arrays_order() -> list:
+    @classmethod
+    def change_antenna_arrays_order(cls) -> list:
         """
         Returns the correct field 'antenna_arrays_order' for a bfiq file
 

--- a/postprocessors/core/antennas_iq_to_bfiq.py
+++ b/postprocessors/core/antennas_iq_to_bfiq.py
@@ -40,6 +40,7 @@ class AntennasIQ2Bfiq(BaseConvert):
     outfile_structure: str
         The desired structure of the output file. Same structures as above, plus 'iqdat'.
     """
+    window = [1.0] * 16
 
     def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str):
         """
@@ -185,8 +186,12 @@ class AntennasIQ2Bfiq(BaseConvert):
                 antenna_phase_shifts.append(phase_shift)
 
             # Apply phase shift to data from respective antenna
-            phased_antenna_data = [cls.shift_samples(antennas_data[i], antenna_phase_shifts[i], 1.0)
-                                   for i in range(num_antennas)]
+            if num_antennas == 16:
+                phased_antenna_data = [cls.shift_samples(antennas_data[i], antenna_phase_shifts[i], cls.window[i])
+                                       for i in range(num_antennas)]
+            else:
+                phased_antenna_data = [cls.shift_samples(antennas_data[i], antenna_phase_shifts[i], 1.0)
+                                       for i in range(num_antennas)]
             phased_antenna_data = np.array(phased_antenna_data)
 
             # Sum across antennas to get beamformed data

--- a/postprocessors/core/antennas_iq_to_bfiq.py
+++ b/postprocessors/core/antennas_iq_to_bfiq.py
@@ -6,7 +6,6 @@ to bfiq files.
 """
 import itertools
 from collections import OrderedDict
-from typing import Union
 
 import numpy as np
 from scipy.constants import speed_of_light
@@ -27,7 +26,7 @@ import logging
 postprocessing_logger = logging.getLogger('borealis_postprocessing')
 
 
-class ProcessAntennasIQ2Bfiq(BaseConvert):
+class AntennasIQ2Bfiq(BaseConvert):
     """
     Class for conversion of Borealis antennas_iq files into bfiq files. This class inherits from
     BaseConvert, which handles all functionality generic to postprocessing borealis files.
@@ -36,7 +35,6 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
     --------
     ConvertFile
     BaseConvert
-    ProcessAntennasIQ2Rawacf
 
     Attributes
     ----------
@@ -45,14 +43,14 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
     outfile: str
         The file name of output file
     infile_structure: str
-        The write structure of the file. Structures include:
+        The structure of the file. Structures include:
         'array'
         'site'
     outfile_structure: str
         The desired structure of the output file. Same structures as above, plus 'iqdat'.
     """
 
-    def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str, **kwargs):
+    def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str):
         """
         Initialize the attributes of the class.
 
@@ -69,10 +67,8 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
         """
         super().__init__(infile, outfile, 'antennas_iq', 'bfiq', infile_structure, outfile_structure)
 
-        self.process_file(**kwargs)
-
     @classmethod
-    def process_record(cls, record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+    def process_record(cls, record: OrderedDict, **kwargs) -> OrderedDict:
         """
         Takes a record from an antennas_iq file and converts it into a bfiq record.
 
@@ -80,8 +76,6 @@ class ProcessAntennasIQ2Bfiq(BaseConvert):
         ----------
         record: OrderedDict
             hdf5 record containing antennas_iq data and metadata
-        averaging_method: Union[None, str]
-            Method to use for averaging correlations across sequences. Unused by this method.
 
         Returns
         -------

--- a/postprocessors/core/antennas_iq_to_rawacf.py
+++ b/postprocessors/core/antennas_iq_to_rawacf.py
@@ -5,12 +5,11 @@ This file contains functions for converting antennas_iq files
 to rawacf files.
 """
 from collections import OrderedDict
-from typing import Union
 
-from postprocessors import BaseConvert, ProcessAntennasIQ2Bfiq, ProcessBfiq2Rawacf
+from postprocessors import BaseConvert, AntennasIQ2Bfiq, Bfiq2Rawacf
 
 
-class ProcessAntennasIQ2Rawacf(BaseConvert):
+class AntennasIQ2Rawacf(BaseConvert):
     """
     Class for conversion of Borealis antennas_iq files into rawacf files. This class inherits from
     BaseConvert, which handles all functionality generic to postprocessing borealis files.
@@ -19,8 +18,8 @@ class ProcessAntennasIQ2Rawacf(BaseConvert):
     --------
     ConvertFile
     BaseConvert
-    ProcessAntennasIQ2Bfiq
-    ProcessBfiq2Rawacf
+    AntennasIQ2Bfiq
+    Bfiq2Rawacf
 
     Attributes
     ----------
@@ -29,15 +28,14 @@ class ProcessAntennasIQ2Rawacf(BaseConvert):
     outfile: str
         The file name of output file
     infile_structure: str
-        The write structure of the file. Structures include:
+        The structure of the file. Structures include:
         'array'
         'site'
     outfile_structure: str
         The desired structure of the output file. Same structures as above, plus 'dmap'.
     """
 
-    def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str,
-                 averaging_method: str = 'mean', **kwargs):
+    def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str):
         """
         Initialize the attributes of the class.
 
@@ -51,16 +49,11 @@ class ProcessAntennasIQ2Rawacf(BaseConvert):
             Borealis structure of input file. Either 'array' or 'site'.
         outfile_structure: str
             Borealis structure of output file. Either 'array', 'site', or 'dmap'.
-        averaging_method: str
-            Method for averaging correlations across sequences. Either 'median' or 'mean'.
         """
         super().__init__(infile, outfile, 'antennas_iq', 'rawacf', infile_structure, outfile_structure)
-        self.averaging_method = averaging_method
-
-        self.process_file(**kwargs)
 
     @classmethod
-    def process_record(cls, record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+    def process_record(cls, record: OrderedDict, **kwargs) -> OrderedDict:
         """
         Takes a record from an antennas_iq file process into a rawacf record.
 
@@ -68,15 +61,13 @@ class ProcessAntennasIQ2Rawacf(BaseConvert):
         ----------
         record: OrderedDict
             hdf5 record containing antennas_iq data and metadata
-        averaging_method: Union[None, str]
-            Method to use for averaging correlations across sequences. Acceptable methods are 'median' and 'mean'
 
         Returns
         -------
         record: OrderedDict
             hdf5 record, with new fields required by rawacf data format
         """
-        record = ProcessAntennasIQ2Bfiq.process_record(record, averaging_method)
-        record = ProcessBfiq2Rawacf.process_record(record, averaging_method)
+        record = AntennasIQ2Bfiq.process_record(record, **kwargs)
+        record = Bfiq2Rawacf.process_record(record, **kwargs)
 
         return record

--- a/postprocessors/core/antennas_iq_to_rawacf.py
+++ b/postprocessors/core/antennas_iq_to_rawacf.py
@@ -67,7 +67,7 @@ class AntennasIQ2Rawacf(AntennasIQ2Bfiq, Bfiq2Rawacf):
         record: OrderedDict
             hdf5 record, with new fields required by rawacf data format
         """
-        record = super().process_record(record, **kwargs)   # This calls AntennasIQ2Bfiq.process_record()
-        record = Bfiq2Rawacf.process_record(record, **kwargs)
+        record = super(AntennasIQ2Rawacf, cls).process_record(record, **kwargs) # Calls AntennasIQ2Bfiq.process_record()
+        record = super(AntennasIQ2Bfiq, cls).process_record(record, **kwargs)   # Calls Bfiq2Rawacf.process_record()
 
         return record

--- a/postprocessors/core/antennas_iq_to_rawacf.py
+++ b/postprocessors/core/antennas_iq_to_rawacf.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from postprocessors import BaseConvert, AntennasIQ2Bfiq, Bfiq2Rawacf
 
 
-class AntennasIQ2Rawacf(BaseConvert):
+class AntennasIQ2Rawacf(AntennasIQ2Bfiq, Bfiq2Rawacf):
     """
     Class for conversion of Borealis antennas_iq files into rawacf files. This class inherits from
     BaseConvert, which handles all functionality generic to postprocessing borealis files.
@@ -50,7 +50,7 @@ class AntennasIQ2Rawacf(BaseConvert):
         outfile_structure: str
             Borealis structure of output file. Either 'array', 'site', or 'dmap'.
         """
-        super().__init__(infile, outfile, 'antennas_iq', 'rawacf', infile_structure, outfile_structure)
+        BaseConvert.__init__(self, infile, outfile, 'antennas_iq', 'rawacf', infile_structure, outfile_structure)
 
     @classmethod
     def process_record(cls, record: OrderedDict, **kwargs) -> OrderedDict:
@@ -67,7 +67,7 @@ class AntennasIQ2Rawacf(BaseConvert):
         record: OrderedDict
             hdf5 record, with new fields required by rawacf data format
         """
-        record = AntennasIQ2Bfiq.process_record(record, **kwargs)
+        record = super().process_record(record, **kwargs)   # This calls AntennasIQ2Bfiq.process_record()
         record = Bfiq2Rawacf.process_record(record, **kwargs)
 
         return record

--- a/postprocessors/core/antennas_iq_to_rawacf.py
+++ b/postprocessors/core/antennas_iq_to_rawacf.py
@@ -59,8 +59,8 @@ class ProcessAntennasIQ2Rawacf(BaseConvert):
 
         self.process_file(**kwargs)
 
-    @staticmethod
-    def process_record(record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+    @classmethod
+    def process_record(cls, record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
         """
         Takes a record from an antennas_iq file process into a rawacf record.
 

--- a/postprocessors/core/bfiq_to_rawacf.py
+++ b/postprocessors/core/bfiq_to_rawacf.py
@@ -67,8 +67,8 @@ class ProcessBfiq2Rawacf(BaseConvert):
 
         self.process_file(**kwargs)
 
-    @staticmethod
-    def process_record(record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+    @classmethod
+    def process_record(cls, record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
         """
         Takes a record from a bfiq file and processes it into record for rawacf file.
 
@@ -88,19 +88,19 @@ class ProcessBfiq2Rawacf(BaseConvert):
             averaging_method = 'mean'
         record['averaging_method'] = averaging_method
 
-        correlations = ProcessBfiq2Rawacf.calculate_correlations(record, averaging_method)
+        correlations = cls.calculate_correlations(record, averaging_method)
         record['main_acfs'] = correlations[0]
         record['intf_acfs'] = correlations[1]
         record['xcfs'] = correlations[2]
 
-        record['correlation_descriptors'] = ProcessBfiq2Rawacf.get_correlation_descriptors()
-        record['correlation_dimensions'] = ProcessBfiq2Rawacf.get_correlation_dimensions(record)
-        record = ProcessBfiq2Rawacf.remove_extra_fields(record)
+        record['correlation_descriptors'] = cls.get_correlation_descriptors()
+        record['correlation_dimensions'] = cls.get_correlation_dimensions(record)
+        record = cls.remove_extra_fields(record)
 
         return record
 
-    @staticmethod
-    def calculate_correlations(record: OrderedDict, averaging_method: str) -> tuple:
+    @classmethod
+    def calculate_correlations(cls, record: OrderedDict, averaging_method: str) -> tuple:
         """
         Calculates the auto- and cross-correlations for main and interferometer arrays given the bfiq data in record.
 
@@ -127,13 +127,13 @@ class ProcessBfiq2Rawacf(BaseConvert):
         num_arrays, num_sequences, num_beams, num_samps = record['data_dimensions']
         bfiq_data = bfiq_data.reshape(record['data_dimensions'])
 
-        main_corrs_unavg = ProcessBfiq2Rawacf.correlations_from_samples(bfiq_data[0, ...],
+        main_corrs_unavg = cls.correlations_from_samples(bfiq_data[0, ...],
                                                                         bfiq_data[0, ...],
                                                                         record)
-        intf_corrs_unavg = ProcessBfiq2Rawacf.correlations_from_samples(bfiq_data[1, ...],
+        intf_corrs_unavg = cls.correlations_from_samples(bfiq_data[1, ...],
                                                                         bfiq_data[1, ...],
                                                                         record)
-        cross_corrs_unavg = ProcessBfiq2Rawacf.correlations_from_samples(bfiq_data[1, ...],
+        cross_corrs_unavg = cls.correlations_from_samples(bfiq_data[1, ...],
                                                                          bfiq_data[0, ...],
                                                                          record)
 
@@ -156,8 +156,8 @@ class ProcessBfiq2Rawacf(BaseConvert):
 
         return main_acfs, intf_acfs, xcfs
 
-    @staticmethod
-    def correlations_from_samples(beamformed_samples_1: np.array, beamformed_samples_2: np.array,
+    @classmethod
+    def correlations_from_samples(cls, beamformed_samples_1: np.array, beamformed_samples_2: np.array,
                                   record: OrderedDict) -> np.array:
         """
         Correlate two sets of beamformed samples together. Correlation matrices are used and
@@ -249,15 +249,15 @@ class ProcessBfiq2Rawacf(BaseConvert):
 
         return values
 
-    @staticmethod
-    def get_correlation_descriptors() -> list:
+    @classmethod
+    def get_correlation_descriptors(cls) -> list:
         """
         Returns a list of descriptors corresponding to correlation data dimensions.
         """
         return ['num_beams', 'num_ranges', 'num_lags']
 
-    @staticmethod
-    def get_correlation_dimensions(record: OrderedDict) -> np.array:
+    @classmethod
+    def get_correlation_dimensions(cls, record: OrderedDict) -> np.array:
         """
         Returns the dimensions of correlation data.
 
@@ -272,8 +272,8 @@ class ProcessBfiq2Rawacf(BaseConvert):
         """
         return np.array([len(record['beam_azms']), record['num_ranges'], len(record['lags'])], dtype=np.uint32)
 
-    @staticmethod
-    def remove_extra_fields(record: OrderedDict) -> OrderedDict:
+    @classmethod
+    def remove_extra_fields(cls, record: OrderedDict) -> OrderedDict:
         """
         Removes fields not needed by the rawacf data format.
 

--- a/postprocessors/core/conversion.py
+++ b/postprocessors/core/conversion.py
@@ -102,7 +102,7 @@ class ConvertFile(object):
             )
 
         self._converter = self.get_converter()
-        if self._converter is not BaseConvert:
+        if not isinstance(self._converter, BaseConvert):
             self._converter.process_file(**kwargs)
 
     def get_converter(self):

--- a/postprocessors/core/conversion.py
+++ b/postprocessors/core/conversion.py
@@ -102,7 +102,8 @@ class ConvertFile(object):
             )
 
         self._converter = self.get_converter()
-        self._converter.process_file(**kwargs)
+        if self._converter is not BaseConvert:
+            self._converter.process_file(**kwargs)
 
     def get_converter(self):
         """

--- a/postprocessors/core/conversion.py
+++ b/postprocessors/core/conversion.py
@@ -8,7 +8,7 @@ SuperDARN data files.
 import argparse
 import os
 
-from postprocessors import ProcessAntennasIQ2Bfiq, ProcessBfiq2Rawacf, ProcessAntennasIQ2Rawacf, BaseConvert
+from postprocessors import AntennasIQ2Bfiq, Bfiq2Rawacf, AntennasIQ2Rawacf, BaseConvert
 from postprocessors.core.restructure import FILE_TYPE_MAPPING, restructure
 from postprocessors import conversion_exceptions
 
@@ -19,11 +19,11 @@ def usage_msg():
     This is used if a -h flag or invalid arguments are provided.
     """
 
-    usage_message = """ conversion.py [-h] infile outfile infile_type outfile_type infile_structure outfile_structure [--averaging-method a]
+    usage_message = """ conversion.py [-h] infile outfile infile_type outfile_type infile_structure outfile_structure
     
     Pass in the filename you wish to convert, the filename you wish to save as, and the types and structures of both.
     The script will convert the input file into an output file of type "outfile_type" and structure "outfile_structure".
-    If the final type is rawacf, the averaging method may optionally be specified as well. """
+    """
 
     return usage_message
 
@@ -43,8 +43,6 @@ def conversion_parser():
                         help="Structure of input file.")
     parser.add_argument("outfile_structure", metavar="outfile-structure", choices=['array', 'site', 'iqdat', 'dmap'],
                         help="Structure of output file.")
-    parser.add_argument("-a", "--averaging-method", required=False, default='mean', choices=['mean', 'median'],
-                        help="Averaging method for generating rawacf type file. Default mean.")
 
     return parser
 
@@ -77,7 +75,7 @@ class ConvertFile(object):
     outfile_type: str
         Desired type of output data file. Same types as above.
     infile_structure: str
-        The write structure of the file. Structures include:
+        The structure of the file. Structures include:
         'array'
         'site'
     outfile_structure: str
@@ -86,20 +84,16 @@ class ConvertFile(object):
         'site'
         'iqdat' (bfiq only)
         'dmap' (rawacf only)
-    averaging_method: str
-        Averaging method for computing correlations (for processing into rawacf files).
-        Acceptable values are 'mean' and 'median'.
     """
 
     def __init__(self, infile: str, outfile: str, infile_type: str, outfile_type: str,
-                 infile_structure: str, outfile_structure: str, averaging_method: str = 'mean'):
+                 infile_structure: str, outfile_structure: str, **kwargs):
         self.infile = infile
         self.outfile = outfile
         self.infile_type = infile_type
         self.outfile_type = outfile_type
         self.infile_structure = infile_structure
         self.outfile_structure = outfile_structure
-        self.averaging_method = averaging_method
         self._temp_files = []
 
         if not os.path.isfile(self.infile):
@@ -108,6 +102,7 @@ class ConvertFile(object):
             )
 
         self._converter = self.get_converter()
+        self._converter.process_file(**kwargs)
 
     def get_converter(self):
         """
@@ -137,11 +132,9 @@ class ConvertFile(object):
 
         if self.infile_type == 'antennas_iq':
             if self.outfile_type == 'bfiq':
-                return ProcessAntennasIQ2Bfiq(self.infile, self.outfile, self.infile_structure,
-                                              self.outfile_structure)
+                return AntennasIQ2Bfiq(self.infile, self.outfile, self.infile_structure, self.outfile_structure)
             elif self.outfile_type == 'rawacf':
-                return ProcessAntennasIQ2Rawacf(self.infile, self.outfile, self.infile_structure,
-                                                self.outfile_structure, self.averaging_method)
+                return AntennasIQ2Rawacf(self.infile, self.outfile, self.infile_structure, self.outfile_structure)
             else:
                 raise conversion_exceptions.ConversionUpstreamError(
                     f'Conversion from {self.infile_type} to {self.outfile_type} is not supported. Only downstream '
@@ -150,8 +143,7 @@ class ConvertFile(object):
                 )
         elif self.infile_type == 'bfiq':
             if self.outfile_type == 'rawacf':
-                return ProcessBfiq2Rawacf(self.infile, self.outfile, self.infile_structure, self.outfile_structure,
-                                          self.averaging_method)
+                return Bfiq2Rawacf(self.infile, self.outfile, self.infile_structure, self.outfile_structure)
             else:
                 raise conversion_exceptions.ConversionUpstreamError(
                     f'Conversion from {self.infile_type} to {self.outfile_type} is not supported. Only downstream '
@@ -171,7 +163,7 @@ def main():
     args = parser.parse_args()
 
     ConvertFile(args.infile, args.outfile, args.infile_type, args.outfile_type, args.infile_structure,
-                args.outfile_structure, averaging_method=args.averaging_method)
+                args.outfile_structure)
 
 
 if __name__ == "__main__":

--- a/postprocessors/core/convert_base.py
+++ b/postprocessors/core/convert_base.py
@@ -263,8 +263,8 @@ class BaseConvert(object):
             if os.path.exists(filename):
                 os.remove(filename)
 
-    @staticmethod
-    def process_record(record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+    @classmethod
+    def process_record(cls, record: OrderedDict, **kwargs) -> OrderedDict:
         """
         This method should be overwritten by child classes, and should contain the necessary
         steps to process a record of input type to output type.
@@ -273,8 +273,6 @@ class BaseConvert(object):
         ----------
         record: OrderedDict
             An hdf5 group containing one record of site-structured data
-        averaging_method: Union[None, str]
-            Method to use for averaging correlations across sequences.
 
         Returns
         -------

--- a/postprocessors/core/convert_base.py
+++ b/postprocessors/core/convert_base.py
@@ -1,8 +1,7 @@
 # Copyright 2021 SuperDARN Canada, University of Saskatchewan
 # Author: Remington Rohel
 """
-This file contains functions for converting antennas_iq files
-to bfiq files.
+This file contains base functionality for postprocessing of Borealis data files.
 """
 import os
 import traceback
@@ -28,8 +27,7 @@ import logging
 postprocessing_logger = logging.getLogger('borealis_postprocessing')
 
 
-def processing_machine(idx: int, filename: str, record_keys: list, records_per_process: int,
-                       averaging_method: str, processing_fn, **kwargs):
+def processing_machine(idx: int, filename: str, record_keys: list, records_per_process: int, processing_fn, **kwargs):
     """
     Helper function for processing a single record. It is defined here to facilitate multiprocessing.
 
@@ -43,8 +41,6 @@ def processing_machine(idx: int, filename: str, record_keys: list, records_per_p
         List of all top-level keys of the HDF5 file.
     records_per_process: int
         Number of records to process per call to this function.
-    averaging_method: str
-        Method for averaging rawacf data. Either 'mean' or 'median'
     processing_fn: callable
         Function to call to process a record.
     kwargs: dict
@@ -63,7 +59,7 @@ def processing_machine(idx: int, filename: str, record_keys: list, records_per_p
             for num in range(idx + 1, min(idx + records_per_process, len(record_keys))):
                 record_list.append(rs.read_group(hdf5_file[record_keys[num]]))
 
-    processed_record = processing_fn(record_dict, averaging_method, extra_records=record_list, **kwargs)
+    processed_record = processing_fn(record_dict, extra_records=record_list, **kwargs)
 
     if processed_record is None:
         return None, idx
@@ -100,7 +96,7 @@ class BaseConvert(object):
     outfile_type: str
         Desired type of output data file. Same types as above.
     infile_structure: str
-        The write structure of the file. Structures include:
+        The structure of the file. Structures include:
         'array'
         'site'
         'iqdat' (bfiq only)
@@ -174,15 +170,10 @@ class BaseConvert(object):
         Applies appropriate downstream processing to convert between file types (for site-structured
         files only). The processing chain is as follows:
         1. Restructure to site format
-        2. Apply appropriate downstream processing
+        2. Apply appropriate downstream processing by calling process_record() on each record
         3. Restructure to final format
         4. Remove all intermediate files created along the way
 
-        See Also
-        --------
-        ProcessAntennasIQ2Bfiq
-        ProcessAntennasIQ2Rawacf
-        ProcessBfiq2Rawacf
         """
 
         if os.path.isfile(self.outfile) and not kwargs.get('force', False):
@@ -237,7 +228,6 @@ class BaseConvert(object):
                 function_to_call = partial(processing_machine,
                                            filename=file_to_process, record_keys=all_records,
                                            records_per_process=records_per_process,
-                                           averaging_method=self.averaging_method,
                                            processing_fn=self.process_record, **kwargs)
                 print()     # Put the progress bar on a newline
 

--- a/postprocessors/sandbox/binomial_beams.py
+++ b/postprocessors/sandbox/binomial_beams.py
@@ -1,0 +1,65 @@
+# Copyright 2023 SuperDARN Canada, University of Saskatchewan
+
+"""
+This file contains functions for converting antennas_iq files from widebeam experiments
+to rawacf files, using a Binomial window in amplitude for beamforming to reduce receiver sidelobes.
+"""
+from typing import Union
+
+from postprocessors.sandbox.hamming_beams import HammingWindowBeamforming
+
+
+class BinomialWindowBeamforming(HammingWindowBeamforming):
+    """
+    Class for conversion of Borealis antennas_iq files into rawacf files for beam-broadening experiments. This class
+    inherits from BaseConvert, which handles all functionality generic to postprocessing borealis files. The beams
+    are formed using a Binomial window and standard beamforming, to remove sidelobes.
+
+    See Also
+    --------
+    ConvertFile
+    BaseConvert
+    HammingWindowBeamforming
+
+    Attributes
+    ----------
+    infile: str
+        The filename of the input antennas_iq file.
+    outfile: str
+        The file name of output file
+    infile_structure: str
+        The write structure of the file. Structures include:
+        'array'
+        'site'
+    outfile_structure: str
+        The desired structure of the output file. Same structures as above, plus 'dmap'.
+    beam_azms: list[float]
+        List of all beam directions (in degrees) to reprocess into
+    beam_nums: list[uint]
+        List describing beam order. Numbers in this list correspond to indices of beam_azms
+    """
+    window = [0.0001554001554001554, 0.002331002331002331, 0.016317016317016316, 0.0707070707070707,
+              0.21212121212121213, 0.4666666666666667, 0.7777777777777778, 1.0,
+              1.0, 0.7777777777777778, 0.4666666666666667, 0.21212121212121213,
+              0.0707070707070707, 0.016317016317016316, 0.002331002331002331, 0.0001554001554001554]
+    def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str,
+                 beam_azms: Union[list, None] = None, beam_nums: Union[list, None] = None):
+        """
+        Initialize the attributes of the class.
+
+        Parameters
+        ----------
+        infile: str
+            Path to input file.
+        outfile: str
+            Path to output file.
+        infile_structure: str
+            Borealis structure of input file. Either 'array' or 'site'.
+        outfile_structure: str
+            Borealis structure of output file. Either 'array', 'site', or 'dmap'.
+        beam_azms: list[float]
+            List of all beam directions (in degrees) to reprocess into
+        beam_nums: list[uint]
+            List describing beam order. Numbers in this list correspond to indices of beam_azms
+        """
+        super().__init__(infile, outfile, infile_structure, outfile_structure, beam_azms, beam_nums)

--- a/postprocessors/sandbox/binomial_beams.py
+++ b/postprocessors/sandbox/binomial_beams.py
@@ -42,6 +42,7 @@ class BinomialWindowBeamforming(HammingWindowBeamforming):
               0.21212121212121213, 0.4666666666666667, 0.7777777777777778, 1.0,
               1.0, 0.7777777777777778, 0.4666666666666667, 0.21212121212121213,
               0.0707070707070707, 0.016317016317016316, 0.002331002331002331, 0.0001554001554001554]
+
     def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str,
                  beam_azms: Union[list, None] = None, beam_nums: Union[list, None] = None):
         """

--- a/postprocessors/sandbox/bistatic_processing.py
+++ b/postprocessors/sandbox/bistatic_processing.py
@@ -8,7 +8,7 @@ from typing import Union
 import h5py
 import numpy as np
 
-from postprocessors import BaseConvert, ProcessAntennasIQ2Rawacf
+from postprocessors import BaseConvert, AntennasIQ2Rawacf
 
 
 class BistaticProcessing(BaseConvert):
@@ -138,6 +138,6 @@ class BistaticProcessing(BaseConvert):
         record['num_sequences'] = np.int64(len(keep_indices))
         record['sqn_timestamps'] = record['sqn_timestamps'][keep_indices]
 
-        record = ProcessAntennasIQ2Rawacf.process_record(record, averaging_method)
+        record = AntennasIQ2Rawacf.process_record(record, averaging_method)
 
         return record

--- a/postprocessors/sandbox/hamming_beams.py
+++ b/postprocessors/sandbox/hamming_beams.py
@@ -1,0 +1,125 @@
+# Copyright 2021 SuperDARN Canada, University of Saskatchewan
+
+"""
+This file contains functions for converting antennas_iq files from widebeam experiments
+to rawacf files, using a Hamming window in amplitude for beamforming to reduce receiver sidelobes.
+"""
+from collections import OrderedDict
+from typing import Union
+import numpy as np
+
+from postprocessors import BaseConvert, ProcessAntennasIQ2Bfiq, ProcessBfiq2Rawacf
+
+
+class HammingWindowBeamforming(BaseConvert):
+    """
+    Class for conversion of Borealis antennas_iq files into rawacf files for beam-broadening experiments. This class
+    inherits from BaseConvert, which handles all functionality generic to postprocessing borealis files. The beams
+    are formed using a Hamming window and standard beamforming, to keep the largest sidelobe down 40 dB below the
+    main lobe.
+
+    See Also
+    --------
+    ConvertFile
+    BaseConvert
+    ProcessAntennasIQ2Bfiq
+    ProcessBfiq2Rawacf
+    ProcessAntennasIQ2Rawacf
+
+    Attributes
+    ----------
+    infile: str
+        The filename of the input antennas_iq file.
+    outfile: str
+        The file name of output file
+    infile_structure: str
+        The write structure of the file. Structures include:
+        'array'
+        'site'
+    outfile_structure: str
+        The desired structure of the output file. Same structures as above, plus 'dmap'.
+    beam_azms: list[float]
+        List of all beam directions (in degrees) to reprocess into
+    beam_nums: list[uint]
+        List describing beam order. Numbers in this list correspond to indices of beam_azms
+    """
+
+    def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str,
+                 beam_azms: Union[list, None] = None, beam_nums: Union[list, None] = None):
+        """
+        Initialize the attributes of the class.
+
+        Parameters
+        ----------
+        infile: str
+            Path to input file.
+        outfile: str
+            Path to output file.
+        infile_structure: str
+            Borealis structure of input file. Either 'array' or 'site'.
+        outfile_structure: str
+            Borealis structure of output file. Either 'array', 'site', or 'dmap'.
+        beam_azms: list[float]
+            List of all beam directions (in degrees) to reprocess into
+        beam_nums: list[uint]
+            List describing beam order. Numbers in this list correspond to indices of beam_azms
+        """
+        super().__init__(infile, outfile, 'antennas_iq', 'bfiq', infile_structure, outfile_structure)
+
+        # Use default 16-beam arrangement if no beams are specified
+        if beam_azms is None:
+            # Add extra phases here
+            # STD_16_BEAM_ANGLE from superdarn_common_fields
+            self.beam_azms = [-24.3, -21.06, -17.82, -14.58, -11.34, -8.1, -4.86, -1.62, 1.62, 4.86, 8.1, 11.34, 14.58,
+                              17.82, 21.06, 24.3]
+
+            # STD_16_FORWARD_BEAM_ORDER
+            self.beam_nums = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        else:
+            self.beam_azms = beam_azms
+            # Step through beam_azms sequentially if not specified
+            if beam_nums is None:
+                self.beam_nums = range(len(beam_azms))
+            elif len(beam_nums) != len(beam_azms):
+                raise ValueError('beam_nums should be same length as beam_azms.')
+            else:
+                self.beam_nums = beam_nums
+
+        self.process_file(beam_azms=self.beam_azms, beam_nums=self.beam_nums)
+
+    @staticmethod
+    def process_record(record: OrderedDict, averaging_method: Union[None, str], **kwargs) -> OrderedDict:
+        """
+        Takes a record from an antennas_iq file process into a rawacf record.
+        This method also beamforms the antennas_iq data into each of the 16 standard SuperDARN beams,
+        regardless of the beams transmitted, overwriting the fields 'beam_azms' and 'beam_nums'.
+
+        Parameters
+        ----------
+        record: OrderedDict
+            hdf5 record containing antennas_iq data and metadata
+        averaging_method: Union[None, str]
+            Method to use for averaging correlations across sequences. Acceptable methods are 'median' and 'mean'
+
+        Returns
+        -------
+        record: OrderedDict
+            hdf5 record, with new fields required by rawacf data format
+        """
+        record['first_range'] = ProcessAntennasIQ2Bfiq.calculate_first_range(record)
+        record['first_range_rtt'] = ProcessAntennasIQ2Bfiq.calculate_first_range_rtt(record)
+        record['lags'] = ProcessAntennasIQ2Bfiq.create_lag_table(record)
+        record['range_sep'] = ProcessAntennasIQ2Bfiq.calculate_range_separation(record)
+        record['num_ranges'] = ProcessAntennasIQ2Bfiq.get_number_of_ranges(record)
+
+        record['beam_azms'] = np.float64(kwargs['beam_azms'])
+        record['beam_nums'] = np.uint32(kwargs['beam_nums'])
+
+        record['data'] = ProcessAntennasIQ2Bfiq.beamform_data(record)
+        record['data_descriptors'] = ProcessAntennasIQ2Bfiq.get_data_descriptors()
+        record['data_dimensions'] = ProcessAntennasIQ2Bfiq.get_data_dimensions(record)
+        record['antenna_arrays_order'] = ProcessAntennasIQ2Bfiq.change_antenna_arrays_order()
+
+        record = ProcessBfiq2Rawacf.process_record(record, averaging_method)
+
+        return record

--- a/postprocessors/sandbox/hamming_beams.py
+++ b/postprocessors/sandbox/hamming_beams.py
@@ -7,15 +7,6 @@ to rawacf files, using a Hamming window in amplitude for beamforming to reduce r
 from typing import Union
 import numpy as np
 
-try:
-    import cupy as xp
-except ImportError:
-    import numpy as xp
-
-    cupy_available = False
-else:
-    cupy_available = True
-
 from postprocessors import AntennasIQ2Rawacf, AntennasIQ2Bfiq
 
 
@@ -51,10 +42,10 @@ class HammingWindowBeamforming(AntennasIQ2Rawacf):
     beam_nums: list[uint]
         List describing beam order. Numbers in this list correspond to indices of beam_azms
     """
-    hamming_window = [0.08081232549588463, 0.12098514265395757, 0.23455777475180511, 0.4018918165398586,
-                      0.594054435182454, 0.7778186328978896, 0.9214100134552521, 1.0,
-                      1.0, 0.9214100134552521, 0.7778186328978896, 0.594054435182454,
-                      0.4018918165398586, 0.23455777475180511, 0.12098514265395757, 0.08081232549588463]
+    window = [0.08081232549588463, 0.12098514265395757, 0.23455777475180511, 0.4018918165398586,
+              0.594054435182454, 0.7778186328978896, 0.9214100134552521, 1.0,
+              1.0, 0.9214100134552521, 0.7778186328978896, 0.594054435182454,
+              0.4018918165398586, 0.23455777475180511, 0.12098514265395757, 0.08081232549588463]
 
     def __init__(self, infile: str, outfile: str, infile_structure: str, outfile_structure: str,
                  beam_azms: Union[list, None] = None, beam_nums: Union[list, None] = None):
@@ -147,16 +138,16 @@ class HammingWindowBeamforming(AntennasIQ2Rawacf):
             # Apply phase shift to data from respective antenna
             if num_antennas == 16:
                 phased_antenna_data = [AntennasIQ2Bfiq.shift_samples(antennas_data[i], antenna_phase_shifts[i],
-                                                                     cls.hamming_window[i])
+                                                                     cls.window[i])
                                        for i in range(num_antennas)]
             else:
                 phased_antenna_data = [AntennasIQ2Bfiq.shift_samples(antennas_data[i], antenna_phase_shifts[i], 1.0)
                                        for i in range(num_antennas)]
-            phased_antenna_data = xp.array(phased_antenna_data)
+            phased_antenna_data = np.array(phased_antenna_data)
 
             # Sum across antennas to get beamformed data
-            one_beam_data = xp.sum(phased_antenna_data, axis=0)
+            one_beam_data = np.sum(phased_antenna_data, axis=0)
             beamformed_data.append(one_beam_data)
-        beamformed_data = xp.array(beamformed_data)
+        beamformed_data = np.array(beamformed_data)
 
         return beamformed_data

--- a/postprocessors/sandbox/process_impt.py
+++ b/postprocessors/sandbox/process_impt.py
@@ -8,7 +8,7 @@ from typing import Union
 
 import numpy as np
 
-from postprocessors import BaseConvert, ProcessBfiq2Rawacf
+from postprocessors import BaseConvert, Bfiq2Rawacf
 
 
 class ProcessIMPT(BaseConvert):
@@ -101,6 +101,6 @@ class ProcessIMPT(BaseConvert):
                             [0, 24],
                             [43, 43]]
         record['lags'] = np.array(STD_8P_LAG_TABLE, dtype=np.uint32)
-        record = ProcessBfiq2Rawacf.process_record(record, averaging_method)
+        record = Bfiq2Rawacf.process_record(record, averaging_method)
 
         return record

--- a/postprocessors/sandbox/widebeam_antennas_iq_to_bfiq.py
+++ b/postprocessors/sandbox/widebeam_antennas_iq_to_bfiq.py
@@ -8,10 +8,10 @@ from collections import OrderedDict
 from typing import Union
 import numpy as np
 
-from postprocessors import BaseConvert, ProcessAntennasIQ2Bfiq
+from postprocessors import BaseConvert, AntennasIQ2Bfiq
 
 
-class ProcessWidebeamAntennasIQ2Bfiq(BaseConvert):
+class WidebeamAntennasIQ2Bfiq(BaseConvert):
     """
     Class for conversion of Borealis antennas_iq files into rawacf files for beam-broadening experiments. This class
     inherits from BaseConvert, which handles all functionality generic to postprocessing borealis files.
@@ -104,18 +104,18 @@ class ProcessWidebeamAntennasIQ2Bfiq(BaseConvert):
         record: OrderedDict
             hdf5 record, with new fields required by rawacf data format
         """
-        record['first_range'] = ProcessAntennasIQ2Bfiq.calculate_first_range(record)
-        record['first_range_rtt'] = ProcessAntennasIQ2Bfiq.calculate_first_range_rtt(record)
-        record['lags'] = ProcessAntennasIQ2Bfiq.create_lag_table(record)
-        record['range_sep'] = ProcessAntennasIQ2Bfiq.calculate_range_separation(record)
-        record['num_ranges'] = ProcessAntennasIQ2Bfiq.get_number_of_ranges(record)
+        record['first_range'] = AntennasIQ2Bfiq.calculate_first_range(record)
+        record['first_range_rtt'] = AntennasIQ2Bfiq.calculate_first_range_rtt(record)
+        record['lags'] = AntennasIQ2Bfiq.create_lag_table(record)
+        record['range_sep'] = AntennasIQ2Bfiq.calculate_range_separation(record)
+        record['num_ranges'] = AntennasIQ2Bfiq.get_number_of_ranges(record)
 
         record['beam_azms'] = np.float64(kwargs['beam_azms'])
         record['beam_nums'] = np.uint32(kwargs['beam_nums'])
 
-        record['data'] = ProcessAntennasIQ2Bfiq.beamform_data(record)
-        record['data_descriptors'] = ProcessAntennasIQ2Bfiq.get_data_descriptors()
-        record['data_dimensions'] = ProcessAntennasIQ2Bfiq.get_data_dimensions(record)
-        record['antenna_arrays_order'] = ProcessAntennasIQ2Bfiq.change_antenna_arrays_order()
+        record['data'] = AntennasIQ2Bfiq.beamform_data(record)
+        record['data_descriptors'] = AntennasIQ2Bfiq.get_data_descriptors()
+        record['data_dimensions'] = AntennasIQ2Bfiq.get_data_dimensions(record)
+        record['antenna_arrays_order'] = AntennasIQ2Bfiq.change_antenna_arrays_order()
 
         return record

--- a/scripts/bistatic_postprocessing.py
+++ b/scripts/bistatic_postprocessing.py
@@ -6,7 +6,7 @@ import deepdish as dd
 from datetime import datetime
 
 from postprocessors import ConvertFile, borealis_to_borealis_rename
-from postprocessors.sandbox.widebeam_antennas_iq_to_bfiq import ProcessWidebeamAntennasIQ2Bfiq
+from postprocessors.sandbox.widebeam_antennas_iq_to_bfiq import WidebeamAntennasIQ2Bfiq
 from postprocessors.sandbox.bistatic_processing import BistaticProcessing
 
 
@@ -84,7 +84,7 @@ def main(in_directory: str, out_directory: str, out_struct: str, search_pattern:
 
             if experiment_name in ['Widebeam_2tx', 'Widebeam_3tx', 'MultifreqWidebeam']:    # These ones need some love
                 print(f'{path} -> {rawacf_out}  ', end='')
-                ProcessWidebeamAntennasIQ2Bfiq(path, bfiq_path, input_structure, 'site')
+                WidebeamAntennasIQ2Bfiq(path, bfiq_path, input_structure, 'site')
                 ConvertFile(bfiq_path, rawacf_out, 'bfiq', 'rawacf', 'site', out_struct, averaging_method)
                 os.remove(bfiq_path)    # We don't need to keep these around
 

--- a/scripts/memory_limited_postprocessing.py
+++ b/scripts/memory_limited_postprocessing.py
@@ -3,7 +3,7 @@ import glob
 import os
 from datetime import datetime
 
-from postprocessors import borealis_to_borealis_rename, ProcessBfiq2Rawacf, ProcessAntennasIQ2Bfiq
+from postprocessors import borealis_to_borealis_rename, Bfiq2Rawacf, AntennasIQ2Bfiq
 
 
 def main(in_directory: str, out_directory: str, out_struct: str, search_pattern: str):
@@ -59,14 +59,14 @@ def main(in_directory: str, out_directory: str, out_struct: str, search_pattern:
         elif os.path.isfile(bfiq_path):
             # bfiq already exists
             print(f'{bfiq_path} -> {rawacf_out}  ', end='')
-            ProcessBfiq2Rawacf(bfiq_path, rawacf_out, 'site', out_struct, averaging_method, num_processes=1)
+            Bfiq2Rawacf(bfiq_path, rawacf_out, 'site', out_struct, averaging_method, num_processes=1)
             os.remove(bfiq_path)       # Don't want to keep this around
 
         else:
             print(f'{path} -> {bfiq_path} ', end='')
-            ProcessAntennasIQ2Bfiq(path, bfiq_path, input_structure, 'site', num_processes=1)
+            AntennasIQ2Bfiq(path, bfiq_path, input_structure, 'site', num_processes=1)
             print(f'-> {os.path.basename(rawacf_out)}  ', end='')
-            ProcessBfiq2Rawacf(bfiq_path, rawacf_out, 'site', out_struct, averaging_method, num_processes=1)
+            Bfiq2Rawacf(bfiq_path, rawacf_out, 'site', out_struct, averaging_method, num_processes=1)
 
         end = datetime.utcnow()
         duration = (end - start).total_seconds()


### PR DESCRIPTION
* Refactored core processing classes to strip `Process...` prefix from classnames, use `@classmethod` prolifically for inheritance purposes, and use better `super()` calls for proper method overwriting in inherited classes.
* Created two new sandbox classes that inherit from `AntennasIQ2Rawacf` and use amplitude tapers when beamforming for sidelobe reduction
* Removed cupy usage in beamforming, since it is done on CPU at sites regardless